### PR TITLE
ref(psql): use bytea over hex, add key & data examples with views, functions, ctes, etc

### DIFF
--- a/.config/psql/exampledb_xxxxxxxx/psqlrc.encryption.sql
+++ b/.config/psql/exampledb_xxxxxxxx/psqlrc.encryption.sql
@@ -24,13 +24,13 @@ WITH "pgp_example_table_cte" AS (
     SELECT
         'sensitive data (pgp)' AS "plain_original",
         pgp_sym_encrypt(
-			'sensitive data (pgp)',
-			current_setting('my.pgp_password'),
+            'sensitive data (pgp)',
+            current_setting('my.pgp_password'),
             'cipher-algo=aes128, unicode-mode=1'
         ) AS "pgp_enc_column"
 )
 SELECT
-    plain_original,
+    "plain_original",
     -- pgp_sym_decrypt(msg bytea, psw text [, options text ]) returns text
     -- pgp_sym_decrypt_bytea(msg bytea, psw text [, options text ]) returns bytea
     pgp_sym_decrypt(
@@ -52,8 +52,8 @@ LANGUAGE sql
 IMMUTABLE
 PARALLEL SAFE
 AS $$
-	-- encrypt(data bytea, key bytea, type text) returns bytea
-	-- encrypt_iv(data bytea, key bytea, iv bytea, type text) returns bytea
+    -- encrypt(data bytea, key bytea, type text) returns bytea
+    -- encrypt_iv(data bytea, key bytea, iv bytea, type text) returns bytea
     -- default 'type' is 'aes-cbc/pad:pkcs'
     SELECT encrypt(convert_to(plain_text, 'UTF8'), decode(aes_key_hex, 'hex'), 'aes')
 $$;
@@ -64,8 +64,8 @@ LANGUAGE sql
 IMMUTABLE
 PARALLEL SAFE
 AS $$
-	-- decrypt(data bytea, key bytea, type text) returns bytea
-	-- decrypt_iv(data bytea, key bytea, iv bytea, type text) returns bytea
+    -- decrypt(data bytea, key bytea, type text) returns bytea
+    -- decrypt_iv(data bytea, key bytea, iv bytea, type text) returns bytea
     -- default 'type' is 'aes-cbc/pad:pkcs'
     SELECT convert_from(decrypt(encrypted_data, decode(aes_key_hex, 'hex'), 'aes'), 'UTF8')
 $$;
@@ -74,17 +74,17 @@ WITH "raw_example_table_cte" AS (
     SELECT
         'sensitive data (raw)' AS "plain_original",
         encrypt_aes_cbc(
-			'sensitive data (raw)',
-			current_setting('my.aes_128_key')
-		) AS "raw_enc_column"
+            'sensitive data (raw)',
+            current_setting('my.aes_128_key')
+        ) AS "raw_enc_column"
 )
 SELECT
 	-- session_decrypt(raw_enc_column::bytea) AS plain_text,
-    plain_original,
-	decrypt_aes_cbc(
-		raw_enc_column,
-		current_setting('my.aes_128_key')
-	) AS "plain_decrypted",
+    "plain_original",
+    decrypt_aes_cbc(
+        "raw_enc_column",
+        current_setting('my.aes_128_key')
+    ) AS "plain_decrypted",
     "raw_enc_column"
 FROM
     "raw_example_table_cte" \gx

--- a/.config/psql/exampledb_xxxxxxxx/psqlrc.encryption.sql
+++ b/.config/psql/exampledb_xxxxxxxx/psqlrc.encryption.sql
@@ -45,8 +45,33 @@ FROM
 -- raw encrypt / decrypt example
 -- https://www.postgresql.org/docs/current/pgcrypto.html#PGCRYPTO-RAW-ENC-FUNCS
 
+WITH "aes_key_cte" AS (
+    SELECT
+        current_setting('my.aes_128_key')::bytea AS "aes_key",
+        'sensitive data (raw)' AS "plain_original"
+),
+"raw_example_table_cte" AS (
+    SELECT
+        "aes_key",
+        "plain_original",
+        encrypt(convert_to("plain_original", 'UTF8'), "aes_key", 'aes') AS "raw_enc_column"
+    FROM
+        "aes_key_cte"
+)
+SELECT
+    "plain_original",
+    "raw_enc_column",
+    convert_from(decrypt("raw_enc_column", "aes_key", 'aes'), 'UTF8') AS "plain_decrypted"
+FROM
+    "raw_example_table_cte"
+\gx
+
+
 -- convenience functions to reduce boilerplate within queries themselves
-CREATE OR REPLACE FUNCTION encrypt_aes_cbc(plain_text text, aes_key bytea)
+-- note: these are all temporary, but they could all be permanent
+
+-- DROP FUNCTION IF EXISTS "pg_encrypt_text" (text,bytea);
+CREATE OR REPLACE FUNCTION "pg_temp".pg_encrypt_text(plain_text text, aes_key bytea)
 RETURNS bytea
 LANGUAGE sql
 IMMUTABLE
@@ -58,7 +83,8 @@ AS $$
     SELECT encrypt(convert_to(plain_text, 'UTF8'), aes_key, 'aes')
 $$;
 
-CREATE OR REPLACE FUNCTION decrypt_aes_cbc(encrypted_data bytea, aes_key bytea)
+-- DROP FUNCTION IF EXISTS "pg_decrypt_text" (bytea,bytea);
+CREATE OR REPLACE FUNCTION "pg_temp".pg_decrypt_text(encrypted_data bytea, aes_key bytea)
 RETURNS text
 LANGUAGE sql
 IMMUTABLE
@@ -70,23 +96,81 @@ AS $$
     SELECT convert_from(decrypt(encrypted_data, aes_key, 'aes'), 'UTF8')
 $$;
 
-WITH "raw_example_table_cte" AS (
-    SELECT
-        'sensitive data (raw)' AS "plain_original",
-        encrypt_aes_cbc(
-            'sensitive data (raw)',
-            current_setting('my.aes_128_key')::bytea
-        ) AS "raw_enc_column"
+-- wraps the key in a function so that the ::bytea cast only happens once per query
+-- DROP FUNCTION IF EXISTS "my_key" ();
+CREATE OR REPLACE FUNCTION "pg_temp".my_key()
+RETURNS bytea
+LANGUAGE sql
+STABLE -- relies on GUC (the key is different between client sessions), per per-query permanent
+PARALLEL SAFE
+AS $$
+    -- the ::bytea cast breaks the STABLE caching of current_setting('my.foo')
+    SELECT current_setting('my.aes_128_key')::bytea
+$$;
+
+-- conveniently wraps the key and encryption to be efficient across whole queries
+-- DROP FUNCTION IF EXISTS "my_encrypt" (text);
+CREATE OR REPLACE FUNCTION "pg_temp".my_encrypt(text)
+RETURNS bytea
+LANGUAGE sql
+STABLE -- uses my_key() (GUC), but optimizes away the ::bytea cast per query
+PARALLEL SAFE
+AS $$
+    SELECT encrypt(convert_to($1, 'UTF8'), "pg_temp".my_key(), 'aes')
+$$;
+
+-- conveniently wraps the key and decryption to be efficient across whole queries
+-- DROP FUNCTION IF EXISTS "my_decrypt" (text);
+CREATE OR REPLACE FUNCTION "pg_temp".my_decrypt(bytea)
+RETURNS text
+LANGUAGE sql
+STABLE -- uses my_key() (GUC), but optimizes away the ::bytea cast per query
+PARALLEL SAFE
+AS $$
+    SELECT convert_from(decrypt($1, "pg_temp".my_key(), 'aes'), 'UTF8')
+$$;
+
+--
+-- Examples Using the Convenience Functions and Views
+--
+
+CREATE TEMPORARY TABLE IF NOT EXISTS "encrypted_pii_table" (
+    "number" SERIAL PRIMARY KEY,
+    "first_name" VARCHAR(255),
+    "$last_name" BYTEA
+);
+INSERT INTO "encrypted_pii_table" ("first_name", "$last_name")
+VALUES
+    ('John', session_encrypt('Doe')),
+    ('Jane', session_encrypt('Doe')),
+    ('Bob', session_encrypt('Ross'));
+
+CREATE OR REPLACE TEMPORARY VIEW "decrypted_pii_view" AS
+WITH "aes_key" AS (
+    -- just to show the use of a CTE for the key, the optimizations of my_key()
+    -- and my_encrypt() should be the same once query-planned
+    SELECT current_setting('my.aes_128_key')::bytea AS "aes_key"
 )
 SELECT
-    "plain_original",
-    decrypt_aes_cbc(
-        "raw_enc_column",
-        current_setting('my.aes_128_key')::bytea
-    ) AS "plain_decrypted",
-    "raw_enc_column"
+    "number",
+    "first_name",
+    "pg_temp".pg_decrypt_text("$last_name", "aes_key") AS "last_name"
 FROM
-    "raw_example_table_cte" \gx
+    "encrypted_pii_table"
+    CROSS JOIN "aes_key"
+;
+
+SELECT * FROM "encrypted_pii_table";
+SELECT * FROM "decrypted_pii_view";
+
+\echo '==================================================='
+\echo '=              Try it for yourself!               ='
+\echo '==================================================='
+\echo ''
+\echo 'SELECT * FROM "encrypted_pii_table";'
+\echo 'SELECT * FROM "decrypted_pii_view";'
+\echo 'SELECT "first_name", pg_temp.my_decrypt("$last_name") AS "last_name" FROM "encrypted_pii_table";'
+\echo ''
 
 \echo ''
 \echo '===================================================='

--- a/.config/psql/exampledb_xxxxxxxx/psqlrc.encryption.sql
+++ b/.config/psql/exampledb_xxxxxxxx/psqlrc.encryption.sql
@@ -79,7 +79,6 @@ WITH "raw_example_table_cte" AS (
         ) AS "raw_enc_column"
 )
 SELECT
-	-- session_decrypt(raw_enc_column::bytea) AS plain_text,
     "plain_original",
     decrypt_aes_cbc(
         "raw_enc_column",

--- a/.config/psql/exampledb_xxxxxxxx/psqlrc.encryption.sql
+++ b/.config/psql/exampledb_xxxxxxxx/psqlrc.encryption.sql
@@ -34,10 +34,10 @@ SELECT
     -- pgp_sym_decrypt(msg bytea, psw text [, options text ]) returns text
     -- pgp_sym_decrypt_bytea(msg bytea, psw text [, options text ]) returns bytea
     pgp_sym_decrypt(
-        "pgp_enc_column"::bytea,
-        current_setting('my.pgp_password')::text,
-        'cipher-algo=aes128, unicode-mode=1'::text
-    )::text AS "plain_decrypted",
+        "pgp_enc_column",
+        current_setting('my.pgp_password'),
+        'cipher-algo=aes128, unicode-mode=1'
+    ) AS "plain_decrypted",
     "pgp_enc_column"
 FROM
     "pgp_example_table_cte" \gx

--- a/.config/psql/exampledb_xxxxxxxx/psqlrc.encryption.sql
+++ b/.config/psql/exampledb_xxxxxxxx/psqlrc.encryption.sql
@@ -61,7 +61,10 @@ WITH "aes_key_cte" AS (
 SELECT
     "plain_original",
     "raw_enc_column",
-    convert_from(decrypt("raw_enc_column", "aes_key", 'aes'), 'UTF8') AS "plain_decrypted"
+	convert_from(decrypt("raw_enc_column", "aes_key", 'aes'), 'UTF8') AS "plain_decrypted",
+    convert_from(decrypt_iv(
+        "raw_enc_column", "aes_key", E'\\x00000000000000000000000000000000', 'aes'),
+    'UTF8') AS "plain_decrypted_iv"
 FROM
     "raw_example_table_cte"
 \gx

--- a/.config/psql/exampledb_xxxxxxxx/psqlrc.sql
+++ b/.config/psql/exampledb_xxxxxxxx/psqlrc.sql
@@ -18,11 +18,12 @@ SET SESSION "foo"."test_user_id" = '0192183e-b61-77c5-aeea-2d735b0f0881';
 SET SESSION "foo"."test_timezone" = 'America/New_York';
 SET SESSION "foo"."role" = 'read-only-user';
 
--- ex: use anywhere that you can select
+-- ex: you can use SESSION params anywhere that you can SELECT
 --
 -- SELECT
 --     current_setting('my.client_id') AS client_id,
---     current_setting('my.test_user_id') AS user_id,
---     current_setting('my.test_timezone') AS timezone;
+--     current_setting('my.aes_128_key') AS client_id,
+--     current_setting('foo.test_user_id') AS user_id,
+--     current_setting('foo.test_timezone') AS timezone;
 --
--- SELECT * FROM "customers" WHERE "user_id" = current_setting('my.test_user_id');
+-- SELECT * FROM "customers" WHERE "user_id" = current_setting('foo.test_user_id');

--- a/.config/psql/exampledb_xxxxxxxx/psqlrc.sql
+++ b/.config/psql/exampledb_xxxxxxxx/psqlrc.sql
@@ -10,7 +10,9 @@
 
 -- ex: add conventional "my" extension with client params for pgp and raw encryption
 SET SESSION "my"."client_id" = '12345678';
-SET SESSION "my"."aes_128_key" = 'deadbeefbadc0ffee0ddf00dcafebabe';
+-- note: MUST be cast to ::bytea explicitly
+--       SELECT current_setting('my.aes_128_key')::bytea;
+SET SESSION "my"."aes_128_key" = E'\\xdeadbeefbadc0ffee0ddf00dcafebabe';
 SET SESSION "my"."pgp_password" = 'zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo right';
 
 -- ex: add arbitrary "foo" extension params for various debug and audit parameters
@@ -22,7 +24,7 @@ SET SESSION "foo"."role" = 'read-only-user';
 --
 -- SELECT
 --     current_setting('my.client_id') AS client_id,
---     current_setting('my.aes_128_key') AS client_id,
+--     current_setting('my.aes_128_key')::bytea AS client_id,
 --     current_setting('foo.test_user_id') AS user_id,
 --     current_setting('foo.test_timezone') AS timezone;
 --


### PR DESCRIPTION
It turns out that, despite what GPT says, it _is_ possible to store a session param as a bytea - I just didn't have the syntax correct previously.

```diff
  -- TEXT (hex)
- SET SESSION "my"."aes_128_key" = 'deadbeefbadc0ffee0ddf00dcafebabe';
  -- BYTEA (escaped)
+ SET SESSION "my"."aes_128_key" = E'\\xdeadbeefbadc0ffee0ddf00dcafebabe';
```