### PR TITLE
fix(psql): add back missing confdir

### DIFF
--- a/.config/psql/exampledb_xxxxxxxx/psqlrc.encryption.sql
+++ b/.config/psql/exampledb_xxxxxxxx/psqlrc.encryption.sql
@@ -134,7 +134,7 @@ AS $$
 $$;
 
 -- conveniently wraps the key and decryption to be efficient across whole queries
--- DROP FUNCTION IF EXISTS "my_decrypt" (text);
+-- DROP FUNCTION IF EXISTS "my_decrypt" (bytea);
 CREATE OR REPLACE FUNCTION "pg_temp".my_decrypt(bytea)
 RETURNS text
 LANGUAGE sql

--- a/.config/psql/psqlrc.sql
+++ b/.config/psql/psqlrc.sql
@@ -4,9 +4,10 @@
 -- Per-DB Configuration
 --
 \set HISTFILE ~/.config/psql/ :DBNAME /history
-\set dbrc ~/.config/psql/ :DBNAME /psqlrc.sql
-\if `mkdir -p :CONFDIR && chmod 0700 :CONFDIR && echo n || echo y`
-    \echo [WARN] could not create :CONFDIR
+\set confdir ~/.config/psql/ :DBNAME
+\set dbrc :confdir /psqlrc.sql
+\if `mkdir -p :confdir && chmod 0700 :confdir && echo n || echo y`
+    \echo [WARN] could not create :confdir
     \set HISTFILE ~/.config/psql/history
 \else
     \if `test -f :dbrc || touch :dbrc && chmod 0600 :dbrc && echo n || echo y`


### PR DESCRIPTION
`:CONFDIR` was there (and tested), but something happened in the last commit just before commit.

Well, we'll rename it `:confdir` to be clear its not a built-in anyway.